### PR TITLE
GitHub actions CI with ruby version build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
+    name: Run Tests (Ruby ${{ matrix.ruby }})
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          architecture: 'x64'
+      - run: |
+        gem install bundler
+        bundle
+        rake
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           architecture: 'x64'
-      - run: |
-        gem install bundler
-        bundle
-        rake
+      - name: Run tests
+        run: |
+          gem install bundler
+          bundle
+          rake
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ If you use more of Twilio, consider [twilio-ruby](https://github.com/twilio/twil
 
 ## Usage
 
+Twilito should work on Ruby 2.4 and up.
+
 #### Install the gem
 
 ```

--- a/lib/twilito/api.rb
+++ b/lib/twilito/api.rb
@@ -7,7 +7,7 @@ module Twilito
 
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         req = Net::HTTP::Post.new(uri)
-        req.initialize_http_header({ 'User-Agent' => "Ruby Twilito/#{Twilito::VERSION}" })
+        req.initialize_http_header('User-Agent' => user_agent)
         req.basic_auth(args[:account_sid], args[:auth_token])
         req.set_form_data(twilio_params(args))
 
@@ -37,6 +37,10 @@ module Twilito
         'From' => args[:from],
         'Body' => args[:body]
       }
+    end
+
+    def user_agent
+      "Ruby Twilito/#{Twilito::VERSION}"
     end
   end
 end


### PR DESCRIPTION
* Adds GitHub actions workflow to run minitest across maintained Ruby versions (2.4, 2.5, 2.6).
* Breaks out `user_agent` in `Twilito::API` as a result of rubocop offense