### PR TITLE
Add Ruby 2.7.0 to build matrix, address some warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4.x', '2.5.x', '2.6.x' ]
+        ruby: [ '2.4.x', '2.5.x', '2.6.x', '2.7.x' ]
     name: Run Tests (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@master

--- a/lib/twilito.rb
+++ b/lib/twilito.rb
@@ -13,7 +13,7 @@ module Twilito
     include API
 
     def send_sms(**args)
-      response = send_sms!(args)
+      response = send_sms!(**args)
       Result.success(
         response: response,
         sid: JSON.parse(response.read_body)['sid']
@@ -36,7 +36,7 @@ module Twilito
 
     private
 
-    def merge_configuration(**args)
+    def merge_configuration(args)
       configuration.to_h.merge(args).tap do |merged|
         missing_keys = merged.select { |_k, v| v.nil? }.keys
 


### PR DESCRIPTION
Make sure things still pass on 2.7.x

There are still some deprecation warnings in `Twilito::Result` which I wasn't able to reconcile quickly. Opened a new issue #8 for those.