### PR TITLE
Accept MediaUrl to allow MMS messages

### DIFF
--- a/lib/twilito/api.rb
+++ b/lib/twilito/api.rb
@@ -35,8 +35,9 @@ module Twilito
       {
         'To' => args[:to],
         'From' => args[:from],
-        'Body' => args[:body]
-      }
+        'Body' => args[:body],
+        'MediaUrl' => args[:media_url]
+      }.compact
     end
 
     def user_agent

--- a/test/send_test.rb
+++ b/test/send_test.rb
@@ -61,6 +61,24 @@ describe Twilito do
           )
         end
       end
+
+      describe 'with media_url passed' do
+        it 'POSTs to Twilio API with correct body, overriding configuration' do
+          Twilito.send_sms(
+            body: 'A media SMS', to: '+17408675309', media_url: 'https://demo.twilio.com/owl.png'
+          )
+
+          assert_requested(
+            :post, 'https://api.twilio.com/2010-04-01/Accounts/ACSID/Messages.json',
+            body: {
+              To: '+17408675309',
+              From: '+16143333333',
+              Body: 'A media SMS',
+              MediaUrl: 'https://demo.twilio.com/owl.png'
+            }
+          )
+        end
+      end
     end
 
     describe 'with an unsuccessful response from Twilio' do


### PR DESCRIPTION
In order to send MMS messages, Twilio accepts `MediaUrl` as a parameter. [Documentation is provided here](https://www.twilio.com/docs/sms/send-messages#include-media-in-your-messages).

This PR simply adds that parameter as an option to the client.
