### PR TITLE
Fixes Ruby 2.7 warnings.

### DIFF
--- a/lib/twilito/result.rb
+++ b/lib/twilito/result.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
 module Twilito
-  Result = Struct.new(:success, :errors, :sid, :response) do
+  class Result
+    attr_reader :success, :errors, :sid, :response
+
     def initialize(success:, errors: [], sid: nil, response: nil)
-      super(success, errors, sid, response)
+      @success = success
+      @errors = errors
+      @sid = sid
+      @response = response
     end
 
-    def self.success(**args)
-      new(success: true, **args)
+    def self.success(response:, sid:)
+      new(success: true, response: response, sid: sid)
     end
 
-    def self.failure(**args)
-      new(success: false, **args)
+    def self.failure(response:, errors:)
+      new(success: false, response: response, errors: errors)
     end
 
     def data
@@ -19,15 +24,15 @@ module Twilito
     end
 
     def success?
-      to_h[:success] || false
+      success || false
     end
 
     private
 
     def response_body
-      return nil unless to_h[:response]&.respond_to?(:read_body)
+      return nil unless response&.respond_to?(:read_body)
 
-      to_h[:response].read_body
+      response.read_body
     end
   end
 end


### PR DESCRIPTION
I don't believe that you can override the constructor of a Struct, though it is weird that it doesn't break things. The code becomes torn between wanting to accept keyword arguments and expecting ordered arguments and ultimately complains about it through the warning.

Turning the class from a Struct into a regular class means we can use keyword arguments in the constructor with no problem.

You could continue to use the `def self.success(**args)` pattern now the class is not a Struct, but I personally prefer the more explicit requirements of the named arguments. What do you think?

Fixes #8.