### PR TITLE
Support StatusCallback params

### DIFF
--- a/lib/twilito/api.rb
+++ b/lib/twilito/api.rb
@@ -36,7 +36,8 @@ module Twilito
         'To' => args[:to],
         'From' => args[:from],
         'Body' => args[:body],
-        'MediaUrl' => args[:media_url]
+        'MediaUrl' => args[:media_url],
+        'StatusCallback' => args[:status_callback]
       }.compact
     end
 

--- a/test/send_test.rb
+++ b/test/send_test.rb
@@ -79,6 +79,22 @@ describe Twilito do
           )
         end
       end
+
+      describe 'with optional parameter passed' do
+        it 'POSTs to Twilio API with optional parameters' do
+          Twilito.send_sms(status_callback: 'https://abc1234.free.beeceptor.com')
+
+          assert_requested(
+            :post, 'https://api.twilio.com/2010-04-01/Accounts/ACSID/Messages.json',
+            body: {
+              To: '+16145555555',
+              From: '+16143333333',
+              Body: 'This is the body',
+              StatusCallback: 'https://abc1234.free.beeceptor.com'
+            }
+          )
+        end
+      end
     end
 
     describe 'with an unsuccessful response from Twilio' do


### PR DESCRIPTION
Allow to send `StatusCallback` parameter.

<img width="534" src="https://user-images.githubusercontent.com/51594/109942920-fbf83680-7d17-11eb-8b7a-6754da4a97e7.png">

https://www.twilio.com/docs/sms/api/message-resource?code-sample=code-create-a-message-and-specify-a-statuscallback-url&code-language=curl&code-sdk-version=json

