### PR TITLE
Update Gemfile.lock to latest Bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ DEPENDENCIES
   yard (~> 0.9)
 
 RUBY VERSION
-   ruby 2.6.1p33
+   ruby 2.7.2p137
 
 BUNDLED WITH
-   2.0.2
+   2.2.14


### PR DESCRIPTION
Address some deprecation errors in CI in certain Ruby versions by bundling with the latest version of `bundler`