### PR TITLE
Support arbitrary API parameters by CamelCasing anything provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twilito
 
-A tiny, zero dependency helper for sending text messages with Twilio. Just enough of a wrapper to abstract away Twilio's REST API for sending messages, without _anything_ else.
+A tiny, zero dependency helper for sending text messages with Twilio. _Just enough_ of a wrapper to abstract away Twilio's REST API for sending messages, without _anything_ else.
 
 [![Gem Version](https://badge.fury.io/rb/twilito.svg)](https://badge.fury.io/rb/twilito) [![Actions Status](https://github.com/alexford/twilito/workflows/CI/badge.svg)](https://github.com/alexford/twilito/actions)
 
@@ -16,7 +16,7 @@ If you use more of Twilio, consider [twilio-ruby](https://github.com/twilio/twil
 
 ## Usage
 
-Twilito should work on Ruby 2.4 and up.
+Twilito should work on Ruby 2.4 and up. Unit tests [run in CI](https://github.com/alexford/twilito/actions) on 2.4, 2.5, 2.6, 2.7, and 3.0.
 
 #### Install the gem
 
@@ -27,7 +27,7 @@ gem 'twilito'
 #### Simplest case
 
 ```ruby
-# All of these arguments are required, but can be defaulted (see below)
+# All of these arguments are required, but can be configured as defaults (see below)
 result = Twilito.send_sms(
   to: '+15555555555',
   from: '+15554444444',
@@ -63,7 +63,9 @@ rescue Twilito::SendError => e
 end
 ```
 
-#### Every argument can be defaulted
+### Configuring Defaults For Required Arguments
+
+The five required arguments (`to`, `from`, `body`, `account_sid`, and `auth_token`) can be configured as defaults with `Twilito.configure`.
 
 ```ruby
 # In an initializer or something like that:
@@ -83,34 +85,21 @@ end
 Twilito.send_sms!(to: '+15555555555', body: 'Foo')
 ```
 
-**Everything can be defaulted, including the message body, so that a bare `Twilio.send_sms!` can work in your code**
+### Using Other, Optional (Arbitrary) Arguments
 
-#### Sending MMS
+There are a number of optional parameters defined by Twilio for sending a message (see [the API documentation](https://www.twilio.com/docs/sms/api/message-resource#create-a-message-resource)). Any of these can be sent with Twilito using the "Ruby-style" snake cased equivalent of the parameter.
 
 ```ruby
-# Use the optional media_url argument, which is sent
-# to Twilio as MediaUrl
+# Twilito sends arbitrary arguments to Twilio's API after CamelCasing keys to match Twilio's style.
+# NOTE: This example assumes auth_token, account_sid, and from have already been configured.
 
 result = Twilito.send_sms(
   to: '+15555555555',
   body: 'This is my content',
-  media_url: 'https://example.com/image.png',
+  media_url: 'https://example.com/image.png', # MediaUrl
+  status_callback: 'https://your.app.io/sms/callback', # StatusCallback
+  smart_encoded: true # SmartEncoded
 )
-
-```
-
-#### Set the optional `callback_url` argument if you want to receive HTTP callbacks from Twilio
-
-```ruby
-# Use the optional media_url argument, which is sent
-# to Twilio as MediaUrl
-
-result = Twilito.send_sms(
-  to: '+15555555555',
-  body: 'This is my content',
-  status_callback: 'https://your.app.io/sms/callback',
-)
-
 ```
 
 ## Testing your code

--- a/lib/twilito/api.rb
+++ b/lib/twilito/api.rb
@@ -37,7 +37,7 @@ module Twilito
     def twilio_form_data(args)
       args
         .merge(auth_token: nil, account_sid: nil).compact
-        .transform_keys { |key| key.to_s.split('_').collect(&:capitalize).join }
+        .reduce({}) { |result, (k, v)| result.merge(k.to_s.split('_').collect(&:capitalize).join => v) }
     end
 
     def user_agent

--- a/lib/twilito/api.rb
+++ b/lib/twilito/api.rb
@@ -9,7 +9,7 @@ module Twilito
         req = Net::HTTP::Post.new(uri)
         req.initialize_http_header('User-Agent' => user_agent)
         req.basic_auth(args[:account_sid], args[:auth_token])
-        req.set_form_data(twilio_params(args))
+        req.set_form_data(twilio_form_data(args))
 
         http.request(req)
       end
@@ -31,14 +31,13 @@ module Twilito
 
     private
 
-    def twilio_params(args)
-      {
-        'To' => args[:to],
-        'From' => args[:from],
-        'Body' => args[:body],
-        'MediaUrl' => args[:media_url],
-        'StatusCallback' => args[:status_callback]
-      }.compact
+    # NOTE: Converts snake_cased hash of arguments to CamelCase to match Twilio
+    # API expectations. Also, removes auth_token and account_sid as those are
+    # included separately in .send_response as basic auth instead of POST body
+    def twilio_form_data(args)
+      args
+        .merge(auth_token: nil, account_sid: nil).compact
+        .transform_keys { |key| key.to_s.split('_').collect(&:capitalize).join }
     end
 
     def user_agent

--- a/test/send_test.rb
+++ b/test/send_test.rb
@@ -16,6 +16,7 @@ describe Twilito do
   describe '.send_sms' do
     describe 'with a successful response from Twilio' do
       before do
+        # NOTE: See test_helper.rb
         stub_send_request(response_body: { sid: 'some_sid' })
       end
 
@@ -64,25 +65,7 @@ describe Twilito do
 
       describe 'with media_url passed' do
         it 'POSTs to Twilio API with correct body, overriding configuration' do
-          Twilito.send_sms(
-            body: 'A media SMS', to: '+17408675309', media_url: 'https://demo.twilio.com/owl.png'
-          )
-
-          assert_requested(
-            :post, 'https://api.twilio.com/2010-04-01/Accounts/ACSID/Messages.json',
-            body: {
-              To: '+17408675309',
-              From: '+16143333333',
-              Body: 'A media SMS',
-              MediaUrl: 'https://demo.twilio.com/owl.png'
-            }
-          )
-        end
-      end
-
-      describe 'with optional parameter passed' do
-        it 'POSTs to Twilio API with optional parameters' do
-          Twilito.send_sms(status_callback: 'https://abc1234.free.beeceptor.com')
+          Twilito.send_sms(media_url: 'https://demo.twilio.com/owl.png')
 
           assert_requested(
             :post, 'https://api.twilio.com/2010-04-01/Accounts/ACSID/Messages.json',
@@ -90,7 +73,24 @@ describe Twilito do
               To: '+16145555555',
               From: '+16143333333',
               Body: 'This is the body',
-              StatusCallback: 'https://abc1234.free.beeceptor.com'
+              MediaUrl: 'https://demo.twilio.com/owl.png'
+            }
+          )
+        end
+      end
+
+      describe 'with other arbitrary optional arguments passed' do
+        it 'POSTs to Twilio API with optional arguments CamelCased' do
+          Twilito.send_sms(status_callback: 'https://abc1234.free.beeceptor.com', foo_bar: 'baz')
+
+          assert_requested(
+            :post, 'https://api.twilio.com/2010-04-01/Accounts/ACSID/Messages.json',
+            body: {
+              To: '+16145555555',
+              From: '+16143333333',
+              Body: 'This is the body',
+              StatusCallback: 'https://abc1234.free.beeceptor.com',
+              FooBar: 'baz'
             }
           )
         end


### PR DESCRIPTION
Closes #19
Closes #10 
Replaces #22 

This implements conversion of arbitrary Ruby-style `snake_case` arguments into Twilio-friendly `CamelCase` versions and includes them in the POST to Twilio.

There are still five required arguments: `to`, `from`, `body`, `auth_token`, and `account_sid` — but they are the only arguments explicitly defined in Twilito. Optional arguments that were previously added (`MediaUrl` and `StatusCallback`) are no longer defined explicitly but are still covered by this new logic.