### PR TITLE
#26 Require *either* `from` or `messaging_service_sid`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
+        ruby: ["3.0", "3.1", "3.2"]
     name: Run Tests (Ruby ${{ matrix.ruby }})
     steps:
       - uses: actions/checkout@master

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ AllCops:
   Exclude:
     - "bin/**/*"
     - "twilito.gemspec"
+  AllCops:
+    TargetRubyVersion: 3.2
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '>= 2.4.0'
+ruby '>= 3.0'
 
 source "https://rubygems.org"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '>= 3.0'
+ruby '>= 3.0.0'
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,18 +9,18 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
-    coderay (1.1.2)
+    coderay (1.1.3)
     crack (0.4.5)
       rexml
     hashdiff (1.0.1)
-    method_source (0.9.2)
+    method_source (1.0.0)
     minitest (5.11.3)
     parallel (1.19.2)
     parser (2.7.1.3)
       ast (~> 2.4.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
     rainbow (3.0.0)
     rake (13.0.1)
@@ -51,7 +51,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   minitest (~> 5.11)
-  pry
+  pry (~> 0.14)
   rake (~> 13.0)
   rubocop
   twilito!
@@ -59,7 +59,7 @@ DEPENDENCIES
   yard (~> 0.9)
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.2.2p53
 
 BUNDLED WITH
-   2.2.15
+   2.4.19

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ begin
     auth_token: '...'
   )
 rescue Twilito::SendError => e
-  e.message # => 'The error message from Twilio API'
+  e.message # => 'Error from Twilio API'
   e.response # => Raw response (instance of Net::HTTPResponse)
 end
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gem 'twilito'
 # All of these arguments are required, but can be configured as defaults (see below)
 result = Twilito.send_sms(
   to: '+15555555555',
-  from: '+15554444444',
+  from: '+15554444444', # or 'messaging_service_sid'
   body: 'This is my content',
   account_sid: '...', # Twilio Credentials
   auth_token: '...'
@@ -58,14 +58,14 @@ begin
     auth_token: '...'
   )
 rescue Twilito::SendError => e
-  e.message # => 'Error from Twilio API'
+  e.message # => 'The error message from Twilio API'
   e.response # => Raw response (instance of Net::HTTPResponse)
 end
 ```
 
 ### Configuring Defaults For Required Arguments
 
-The five required arguments (`to`, `from`, `body`, `account_sid`, and `auth_token`) can be configured as defaults with `Twilito.configure`.
+The five required arguments (`to`, `from` (or `messaging_service_sid`), `body`, `account_sid`, and `auth_token`) can be configured as defaults with `Twilito.configure`.
 
 ```ruby
 # In an initializer or something like that:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you use more of Twilio, consider [twilio-ruby](https://github.com/twilio/twil
 
 ## Usage
 
-Twilito should work on Ruby 2.4 and up. Unit tests [run in CI](https://github.com/alexford/twilito/actions) on 2.4, 2.5, 2.6, 2.7, 3.0, and 3.1.
+Twilito is designed for currently maintained Ruby versions. (3.0 and up as of 8/2023). Unit tests [run in CI](https://github.com/alexford/twilito/actions) on 3.0, 3.1, and 3.2
 
 #### Install the gem
 

--- a/lib/twilito.rb
+++ b/lib/twilito.rb
@@ -38,6 +38,13 @@ module Twilito
       configuration.to_h.merge(args).tap do |merged|
         missing_keys = merged.select { |_k, v| v.nil? }.keys
 
+        # Only one of :from or :messaging_service_sid must be set
+        missing_keys = [] if (missing_keys == [:from]) || (missing_keys == [:messaging_service_sid])
+        missing_keys = missing_keys.map do |key|
+          key == :from ? "from (or messaging_service_sid)" : key
+        end
+        missing_keys.delete(:messaging_service_sid)
+
         raise ArgumentError, "Missing argument(s): #{missing_keys.join(', ')}" if missing_keys.any?
       end
     end

--- a/lib/twilito/configuration.rb
+++ b/lib/twilito/configuration.rb
@@ -15,7 +15,7 @@ module Twilito
 
   class Configuration
     attr_accessor :account_sid, :auth_token, :from, :to, :body,
-                  :twilio_host, :twilio_version
+                  :twilio_host, :twilio_version, :messaging_service_sid
 
     TWILIO_HOST = 'api.twilio.com'
     TWILIO_VERSION = '2010-04-01'
@@ -24,6 +24,7 @@ module Twilito
       {
         to: to,
         from: from,
+        messaging_service_sid: messaging_service_sid,
         body: body,
         account_sid: account_sid,
         auth_token: auth_token

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -13,10 +13,10 @@ describe Twilito do
       Twilito.send_sms
     end
 
-    assert_match "to, from, body, account_sid, auth_token", error.message
+    assert_match "to, from (or messaging_service_sid), body, account_sid, auth_token", error.message
   end
 
-  it "does not require arguments for .send_sms once configured as defaults" do
+  it "does not include 'missing' arguments that are previously configured in the error message" do
     Twilito.configure do |config|
       config.body = 'foo'
     end
@@ -25,7 +25,7 @@ describe Twilito do
       Twilito.send_sms
     end
 
-    assert_match "to, from, account_sid, auth_token", error.message
+    assert_match "to, from (or messaging_service_sid), account_sid, auth_token", error.message
   end
 
   it "does not require any arguments for .send_sms if they're all configured" do
@@ -38,5 +38,32 @@ describe Twilito do
     end
 
     Twilito.send_sms
+  end
+
+  describe "either from OR messaging_service_sid is required" do
+    before do
+      Twilito.configure do |config|
+        config.to = '+16145555555'
+        config.body = 'foo'
+        config.account_sid = 'ACSID'
+        config.auth_token = 'TOKEN'
+      end
+    end
+
+    it "does not require `from` for .send_sms if `messaging_service_sid` is provided" do
+      Twilito.configure do |config|
+        config.messaging_service_sid = 'MSSID'
+      end
+
+      Twilito.send_sms
+    end
+
+    it "does not require `messaging_service_sid` for .send_sms if `from` is provided" do
+      Twilito.configure do |config|
+        config.from = '+16144444444'
+      end
+
+      Twilito.send_sms
+    end
   end
 end

--- a/test/send_test.rb
+++ b/test/send_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 describe Twilito do
   before do
+    Twilito.reset_configuration!
     Twilito.configure do |config|
       config.to = '+16145555555'
       config.from = '+16143333333'

--- a/twilito.gemspec
+++ b/twilito.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.version       = Twilito::VERSION
   spec.authors       = ["Alex Ford"]
   spec.email         = ["alexford@hey.com"]
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.summary       = "A tiny, zero dependency, and easy to test helper for sending text messages with Twilio"
   spec.homepage      = "https://github.com/alexford/twilito"
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "minitest", "~> 5.11"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry", "~> 0.14"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "webmock", "~> 3.12"


### PR DESCRIPTION
Closes #26, allowing `messaging_service_sid` in lieu of `from`

- [x] Tests/implementation
- [x] Update README
- [x] Run tests against 3.0, 3.1, and 3.2 (no more 2.x)